### PR TITLE
Feat: 일촌 및 이촌 리스트 출력 API

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
 
-from Backend.backend.api.endpoints import friends, auth, users
+from Backend.backend.api.endpoints import friends, auth, users, relationships
 
 api_router = APIRouter(prefix="/api/v1", tags=["api"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(friends.router, prefix="/friends", tags=["friends"])
+api_router.include_router(relationships.router, prefix="/relationships", tags=["relationships"])

--- a/backend/api/endpoints/relationships.py
+++ b/backend/api/endpoints/relationships.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from Backend.backend.crud.relation_crud import get_friends
+from Backend.backend.schemas.friend import friends_related
+from Backend.backend.database import get_db
+from Backend.backend.schemas.friend.friends_related import FriendsFind
+
+router = APIRouter()
+
+
+@router.get("/{id}", response_model=List[FriendsFind])
+async def get_relationships(id: int, session: AsyncSession = Depends(get_db)):
+    friend_relationships = await get_friends(id, session)
+    if not friend_relationships:
+        raise HTTPException(status_code=404, detail="No friend relationships found")
+    for friend in friend_relationships:  # 각 관계를 출력
+        print(friend)
+    return friend_relationships
+
+
+

--- a/backend/crud/relation_crud.py
+++ b/backend/crud/relation_crud.py
@@ -1,0 +1,29 @@
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from Backend.backend.models.friends import Friend
+from Backend.backend.schemas.friend.friends_related import FriendsFind
+
+
+async def get_friends(user_id: int, session: AsyncSession, depth: int = 1, max_depth: int = 3, visited: set = None) -> List[FriendsFind]:
+    query = (
+        select(Friend)
+        .where(
+            user_id == Friend.user_id
+        )
+    )
+    result = await session.execute(query)
+    friends = result.scalars().all()
+
+    friend_list = []
+    for friend in friends:
+        friend_id = friend.friend_id
+        friends_find = FriendsFind(user_id=user_id, friend_id=friend_id, is_deleted=friend.is_deleted)
+        friend_list.append(friends_find)
+        if depth < max_depth:
+            sub_friends = await get_friends(friend_id, session, depth + 1, max_depth, visited)
+            friend_list.extend(sub_friends)
+
+    return friend_list
+
+

--- a/backend/schemas/friend/friends_related.py
+++ b/backend/schemas/friend/friends_related.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from typing import Optional, List
+
+from pydantic import BaseModel
+
+class FriendsFind(BaseModel):
+    user_id: int
+    friend_id: int
+    is_deleted: Optional[bool] = False
+
+    class Config:
+         orm_mode = True


### PR DESCRIPTION
## Summary
사용자의 id를 통해 일촌과 이촌을 확인하는 API 구현

## Description
- api.py에 relationships 라우터 추가
- FriendsFind 스키마 작성 (friends_related.py)
- relation_crud.py 작성
- relationships endpoint 작성 (relationships.py)

## Screenshots
입력 데이터(예시)
![image](https://github.com/user-attachments/assets/8590ae7c-2d5a-4021-80c4-194154d89362)
결과 (입력값 = 2)
![image](https://github.com/user-attachments/assets/2f1bc6c4-da57-49e8-a31a-5c17eec72add)
![image](https://github.com/user-attachments/assets/3fb68d10-2075-4cf1-9740-416c979083fc)

## Test Checklist
- [ ] 입력한 데이터만큼의 친구(일촌)가 모두 출력 되었는지
- [ ] 친구의 친구(이촌)가 출력 되었는지
