### PR TITLE
Feat: 채팅방 생성 및 조회 API

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from Backend.backend.api.endpoints import friends, auth, users, relationships
+from Backend.backend.api.endpoints import friends, auth, users, relationships, chatrooms
 
 api_router = APIRouter(prefix="/api/v1", tags=["api"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(friends.router, prefix="/friends", tags=["friends"])
 api_router.include_router(relationships.router, prefix="/relationships", tags=["relationships"])
+api_router.include_router(chatrooms.router, prefix="/chatrooms", tags=["chatrooms"])

--- a/backend/api/endpoints/chatrooms.py
+++ b/backend/api/endpoints/chatrooms.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from Backend.backend.database import get_db
+from Backend.backend.models.chatrooms import ChatRoom
+from Backend.backend.crud.chatroom_crud import create_chatroom, get_chatroom
+from Backend.backend.schemas.chat.chatroom_create import ChatroomCreate
+
+router = APIRouter()
+
+@router.post("/", response_model=ChatroomCreate)
+async def create_chatrooms(chatroom: ChatroomCreate, session: AsyncSession = Depends(get_db)):
+    return await create_chatroom(chatroom, session)
+
+@router.get("/{user_id}", response_model=List[ChatroomCreate])
+async def get_chatrooms(user_id: int, session: AsyncSession = Depends(get_db)):
+    show_chatroom = await get_chatroom(user_id, session)
+    if not show_chatroom:
+        raise HTTPException(status_code=404, detail="No chatrooms found")
+    return show_chatroom
+
+
+
+# @router.delete("/{user_id}")

--- a/backend/crud/chatroom_crud.py
+++ b/backend/crud/chatroom_crud.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from Backend.backend.models.chatrooms import ChatRoom
+from Backend.backend.schemas.chat.chatroom_create import ChatroomCreate
+
+async def create_chatroom(chatroom: ChatroomCreate, session: AsyncSession) -> ChatRoom:
+    # 기존 채팅방 유무 확인
+    existing_chatroom_query = select(ChatRoom).where(
+        ((ChatRoom.user1_id == chatroom.user1_id) & (ChatRoom.user2_id == chatroom.user2_id)) |
+        ((ChatRoom.user1_id == chatroom.user2_id) & (ChatRoom.user2_id == chatroom.user1_id))
+    )
+    result = await session.execute(existing_chatroom_query)
+    existing_chatroom = result.scalars().first()
+
+    if existing_chatroom:
+        raise HTTPException(status_code=400, detail="Chatroom between these users already exists")
+
+    new_chatroom = ChatRoom(
+        user1_id=chatroom.user1_id,
+        user2_id=chatroom.user2_id,
+        created_at=chatroom.created_at or datetime.datetime.utcnow(),
+        updated_at=chatroom.updated_at or datetime.datetime.utcnow()
+    )
+    session.add(new_chatroom)
+    await session.commit()
+    await session.refresh(new_chatroom)
+    return new_chatroom
+
+async def get_chatroom(user_id: int, session: AsyncSession) -> List[ChatRoom]:
+    query = select(ChatRoom).where((ChatRoom.user1_id == user_id) | (ChatRoom.user2_id == user_id))
+    result = await session.execute(query)
+    return result.scalars().all()

--- a/backend/models/chatrooms.py
+++ b/backend/models/chatrooms.py
@@ -1,0 +1,20 @@
+# models/chatrooms.py
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, ForeignKey, TIMESTAMP
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from Backend.backend.models.user import User
+from Backend.backend.database import Base
+
+class ChatRoom(Base):
+    __tablename__ = 'chatrooms'
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    user1_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user2_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    created_at = Column(TIMESTAMP, default=datetime.utcnow)
+    updated_at = Column(TIMESTAMP, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user1 = relationship("User", foreign_keys=[user1_id])
+    user2 = relationship("User", foreign_keys=[user2_id])

--- a/backend/schemas/chat/chatroom_create.py
+++ b/backend/schemas/chat/chatroom_create.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ChatroomCreate(BaseModel):
+    user1_id: int
+    user2_id: int
+    created_at: Optional[datetime] = datetime.now()
+    updated_at: Optional[datetime] = datetime.now()
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
채팅방 생성 및 조회 API

## Description
- api.py에 chatrooms 라우터 추가
- chatroom_create.py - ChatroomCreate 스키마 생성
- chatrooms.py - ChatRoom 모델 생성
- chatroom_crud.py - 채팅방 생성, 조회관련 함수
- chatrooms.py - chatrooms.py - endpoints 추가

## Screenshot
ex) (1,2), (1,3)의 채팅방

채팅방 생성 (user1_id = 1, user2_id = 3)
<img width="449" alt="스크린샷 2024-07-14 오후 10 36 01" src="https://github.com/user-attachments/assets/0d63194e-1449-4609-97fc-589ebfe77188">
ots

채팅방이 이미 존재하는 경우
<img width="460" alt="스크린샷 2024-07-14 오후 10 40 20" src="https://github.com/user-attachments/assets/5ef5923a-a7d4-48f5-b770-771db87f80fa">

user_id 1 입력 시
<img width="594" alt="스크린샷 2024-07-14 오후 10 35 31" src="https://github.com/user-attachments/assets/c6bc6b47-fc5f-43ba-b912-49a1a56e361d">

user_id에 3 입력 시
<img width="581" alt="스크린샷 2024-07-15 오전 12 05 36" src="https://github.com/user-attachments/assets/b6395cf8-77c7-411b-a8dd-8b3a0a04003e">

## Test Checklist
- [ ] 채팅방의 생성여부 확인

