### PR TITLE
[#36] friend 관계 끊는 코드추가

### DIFF
--- a/backend/crud/user_crud.py
+++ b/backend/crud/user_crud.py
@@ -1,6 +1,8 @@
+from sqlalchemy import delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
+from Backend.backend.models.friends import Friend
 from Backend.backend.models.user import User
 from Backend.backend.schemas.user.user_create import UserCreate
 from Backend.backend.schemas.user.user_update import UserUpdate
@@ -34,6 +36,7 @@ async def update_user(db: AsyncSession, user_id: int, user_update: UserUpdate):
 async def delete_user(db: AsyncSession, user_id: int):
     db_user = await get_user(db, user_id)
     if db_user:
+        await db.execute(delete(Friend).where(or_(Friend.user_id == user_id, Friend.friend_id == user_id)))
         await db.delete(db_user)
         await db.commit()
     return db_user


### PR DESCRIPTION
## Summary
친구 관계도를 끊는 코드를 추가함으로써 회원탈퇴 시, friends 외래키 문제 해결

## Description
- await db.execute(delete(Friend).where(or_(Friend.user_id == user_id, Friend.friend_id == user_id))) -> SQLAlchemy를 사용하여 데이터베이스에서 친구 관계를 삭제하는 비동기 작업입니다

## Screenshots
*실행 결과 스크린샷*

## Test Checklist
- [x] *해당 user가 한 명이라도 친구 관계일 때, api delete 실행시키기 

