### PR TITLE
[#41] 인덱스 await함수 삭제 후 오류 수정

### DIFF
--- a/backend/crud/user_crud.py
+++ b/backend/crud/user_crud.py
@@ -27,7 +27,7 @@ async def create_user(db: AsyncSession, user: UserCreate):
     await db.refresh(db_user)
 
     user_data = UserSearchResult.from_orm(db_user)
-    await es.index(index="users", id=db_user.id, body=user_data.dict())
+    es.index(index="users", id=db_user.id, body=user_data.dict())
 
     return db_user
 
@@ -40,7 +40,7 @@ async def update_user(db: AsyncSession, user_id: int, user_update: UserUpdate):
         await db.refresh(db_user)
 
         user_data = UserSearchResult.from_orm(db_user)
-        await es.index(index="users", id=db_user.id, body=user_data.dict())
+        es.index(index="users", id=db_user.id, body=user_data.dict())
 
     return db_user
 


### PR DESCRIPTION
## Summary
elasticsearch 회원가입, 수정 시 인덱스 추가 부분에서 await 함수 삭제 (지원안했음)

## Description
- await 함수 삭제
-

## Screenshots
*실행 결과 스크린샷*

## Test Checklist
- [ ] 다시 회원가입 해서 오류 뜨는지 확인하기
