### PR TITLE
[#65] Refactor: 일촌 삭제 기능 수정

### DIFF
--- a/backend/crud/friend_crud.py
+++ b/backend/crud/friend_crud.py
@@ -74,7 +74,7 @@ async def accept_friend(db: AsyncSession, friend_id: int, user_id: int, status: 
 async def list_friend(db: AsyncSession, user_id: int):
     result = await db.execute(
         select(Friend).where(
-            and_(Friend.user_id == user_id, Friend.status == "accepted", Friend.is_deleted == False)
+            and_(Friend.user_id == user_id, Friend.status == "accepted")
         )
     )
     friend_list = result.scalars().all()
@@ -87,8 +87,8 @@ async def remove_friend(db: AsyncSession, friend_id: int, user_id: int):
     result = await db.execute(
         select(Friend).where(
             or_(
-                and_(Friend.friend_id == friend_id, Friend.user_id == user_id, Friend.status == "accepted", Friend.is_deleted == False),
-                and_(Friend.friend_id == user_id, Friend.user_id == friend_id, Friend.status == "accepted", Friend.is_deleted == False)
+                and_(Friend.friend_id == friend_id, Friend.user_id == user_id, Friend.status == "accepted"),
+                and_(Friend.friend_id == user_id, Friend.user_id == friend_id, Friend.status == "accepted")
             )
         )
     )
@@ -102,5 +102,5 @@ async def remove_friend(db: AsyncSession, friend_id: int, user_id: int):
     else:
         # 두 개의 레코드에 대해서 is_deleted = true로 변경
         for friend in deleted_friend:
-            friend.is_deleted = True
+            await db.delete(friend)
         await db.commit()


### PR DESCRIPTION

## Summary
is_deleted로 삭제 하는 것 대신 실제 DB에서 delete로 삭제하는 것으로 수정.

## Description
- is_deleted == true가 아닌 db.delete()

## Screenshots
<img width="957" alt="image" src="https://github.com/user-attachments/assets/d6ef0e76-65a0-4604-8405-fd2e62205289">
<img width="967" alt="image" src="https://github.com/user-attachments/assets/442302ee-6a1e-4ac4-b946-85a72f3a3728">

## Test Checklist
- [ ] 일촌 삭제 API를 한 다음에 똑같은 id값에 대해서 일촌 요청 API로 바로 테스트