### PR TITLE
[#68] Refactor: 일촌 수락/거절 기능 수정

### DIFF
--- a/backend/crud/friend_crud.py
+++ b/backend/crud/friend_crud.py
@@ -62,13 +62,17 @@ async def accept_friend(db: AsyncSession, friend_id: int, user_id: int, status: 
     if not friends_to_update:
         # 결과가 없으면 오류 발생
         raise ValueError("pending인 친구 요청이 없습니다.")
+    elif status == "rejected":
+        # 거절인 경우 불필요한 데이터이므로 삭제
+        for friend in friends_to_update:
+            await db.delete(friend)
     else:
-        # 결과가 있으면 상태 업데이트
+        # 수락인 경우
         for friend in friends_to_update:
             friend.status = status
-        # 데이터베이스에 커밋하여 변경 사항 저장
-        await db.commit()
-        return f"Status is updated to {status}"
+    # 데이터베이스에 커밋하여 변경 사항 저장
+    await db.commit()
+    return f"Status is updated to {status}"
 
 # 일촌 리스트 조회
 async def list_friend(db: AsyncSession, user_id: int):


### PR DESCRIPTION

## Summary
status == rejected 일 때 불필요한 데이터이므로 DB에서 삭제하였음. 
이유: 다시 일촌 요청이 안되기도 하고, 프론트에서 swagger 통해 테스트할 때 데이터 번거롭게 삭제하거나 만들 필요가 없어짐.

## Description
- 조건문 분기 추가

## Screenshots
<img width="951" alt="image" src="https://github.com/user-attachments/assets/9831ad07-9b1c-4271-a7b6-feaa12d3c07a">
<img width="957" alt="image" src="https://github.com/user-attachments/assets/5a22c8bf-d54b-4365-ab11-7856e5f10112">

## Test Checklist
- [ ] 일촌 수락/거절 API 테스트시 rejected로 하고 난 다음에 데이터 삭제여부 확인
