### PR TITLE
Fixes [#80] 선물하기 로그 조회

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from Backend.backend.api.endpoints import friends, auth, users, relationships, chatrooms, search, messages, credit, gift, introduction_request
+from Backend.backend.api.endpoints import friends, auth, users, relationships, chatrooms, search, messages, credit, \
+    gift, introduction_request, transactions
 
 api_router = APIRouter(prefix="/api/v1", tags=["api"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
@@ -13,6 +14,7 @@ api_router.include_router(messages.router, prefix="/messages", tags=["messages"]
 api_router.include_router(credit.router, prefix="/users", tags=["credit"])
 api_router.include_router(gift.router, prefix="/gifts", tags=["gift"])
 api_router.include_router(introduction_request.router, prefix="/introduction_request", tags=["introduction_request"])
+api_router.include_router(transactions.router, prefix="/transactions", tags=["transactions"])
 
 
 

--- a/backend/api/endpoints/transactions.py
+++ b/backend/api/endpoints/transactions.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from Backend.backend.crud.transactions_crud import send_transaction, recieve_transaction
+from Backend.backend.database import get_db
+from Backend.backend.schemas.gift.response.gift_log_response import GiftResponseLog
+
+router = APIRouter()
+
+@router.get("/sent/{user_id}", response_model=GiftResponseLog)
+async def read_gift(user_id: int, db: AsyncSession = Depends(get_db)):
+    send_log = await send_transaction(db, user_id=user_id)
+    if not send_log:
+        raise HTTPException(status_code=404, detail="No sent transactions found for the user")
+    return {"transactions": send_log}
+
+@router.get("/received/{user_id}", response_model=GiftResponseLog)
+async def receive_gift(user_id: int, db: AsyncSession = Depends(get_db)):
+    recieve_log = await recieve_transaction(db, friend_id=user_id)
+    if not recieve_log:
+        raise HTTPException(status_code=404, detail="No received transactions found for the user")
+    return {"transactions": recieve_log}

--- a/backend/crud/transactions_crud.py
+++ b/backend/crud/transactions_crud.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from Backend.backend.models.credit_transaction import CreditTransaction
+from Backend.backend.schemas.gift.response.gift_response import GiftResponse
+
+async def send_transaction(db: AsyncSession, user_id: int):
+    result = await db.execute(select(CreditTransaction).filter(CreditTransaction.user_id == user_id))
+    transactions = result.scalars().all()
+    return [GiftResponse.from_send_orm(tx) for tx in transactions]
+
+async def recieve_transaction(db: AsyncSession, friend_id: int):
+    result = await db.execute(select(CreditTransaction).filter(CreditTransaction.friend_id == friend_id))
+    transactions = result.scalars().all()
+    return [GiftResponse.from_receive_orm(tx) for tx in transactions]

--- a/backend/schemas/gift/response/gift_log_response.py
+++ b/backend/schemas/gift/response/gift_log_response.py
@@ -1,0 +1,11 @@
+from typing import List
+from pydantic import BaseModel
+from Backend.backend.schemas.gift.response.gift_response import GiftResponse
+
+class GiftResponseLog(BaseModel):
+    transactions: List[GiftResponse]
+
+    class Config:
+        from_attributes = True
+
+

--- a/backend/schemas/gift/response/gift_response.py
+++ b/backend/schemas/gift/response/gift_response.py
@@ -9,4 +9,24 @@ class GiftResponse(BaseModel):
     updated_at: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes = True
+
+    @staticmethod
+    def from_send_orm(transaction):
+        return GiftResponse(
+            id=transaction.id,
+            user_id=transaction.user_id,
+            friend_id=transaction.friend_id,
+            ct_money=transaction.ct_money,
+            updated_at=transaction.updated_at
+        )
+
+    @staticmethod
+    def from_receive_orm(transaction):
+        return GiftResponse(
+            id=transaction.id,
+            user_id=transaction.friend_id,  # recieve에선 해당 위치 바꿈 why? 같은 스키마로 활용하기 때문, 프론트지장 x
+            friend_id=transaction.user_id,
+            ct_money=transaction.ct_money,
+            updated_at=transaction.updated_at
+        )


### PR DESCRIPTION
## Summary
선물하기 로그 조회

## Description
- endpoint/transactions.py -> api 명세서에 맞게 작성
- crud/transactions.py -> api 명세서에 맞게 작성
- gift/response/gift_log_response.py -> 해당 gift_response.py의 리스트를 가져옴
- gift/response/gift_response.py -> orm에서 가져온 데이터 필드값 위치 수정 함수 추가하므로, 코드 재사용화

## Screenshots
![image](https://github.com/user-attachments/assets/f952337a-89d7-4637-bf97-1cadae8fd094)
![image](https://github.com/user-attachments/assets/90cf2a06-2c11-4831-a3a5-45c93a9dd382)

## Test Checklist
- [x] id값은 선물하기 로그 고유 데이터베이스 값임 열 순서라고 생각하면 편해용   
- [x] 실제로 선물하기 한 다음, api 실행해보기
