### PR TITLE
Feat/#91 사용자 프로필 이미지 업데이트 API 구현

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -2,6 +2,8 @@ from sqlalchemy import Column, Integer, String, TIMESTAMP, BigInteger
 from sqlalchemy.sql import func
 
 from Backend.backend.database import Base
+from Backend.backend.utils.s3_util import default_profile_url
+
 
 class User(Base):
     __tablename__ = 'users'
@@ -16,7 +18,7 @@ class User(Base):
     company = Column(String, nullable=True)
     region = Column(String(255), nullable=True)
     category = Column(String(255), nullable=True)
-    image_url = Column(String, nullable=True)
+    image_url = Column(String, nullable=True, default=default_profile_url)  # 기본값 추가
     status = Column(String(255), default='오프라인')
     credit = Column(Integer, default=0)
     created_at = Column(TIMESTAMP, server_default=func.now())

--- a/backend/schemas/user/user_schema.py
+++ b/backend/schemas/user/user_schema.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from pydantic import BaseModel
 
+from Backend.backend.utils.s3_util import default_profile_url
+
 formatted_timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
 class User(BaseModel):
@@ -15,7 +17,7 @@ class User(BaseModel):
     job: Optional[str] = None
     company: Optional[str] = None
     category: Optional[str] = None
-    image_url: Optional[str] = None
+    image_url: Optional[str] = default_profile_url
     credit: Optional[int] = None
     created_at: Optional[datetime] = formatted_timestamp
     updated_at: Optional[datetime] = formatted_timestamp

--- a/backend/schemas/user/user_update.py
+++ b/backend/schemas/user/user_update.py
@@ -11,4 +11,3 @@ class UserUpdate(BaseModel):
     company: Optional[str] = None
     region: Optional[str] = None
     category: Optional[str] = None
-    image_url: Optional[str] = None


### PR DESCRIPTION
## Summary
사용자 프로필 이미지 업데이트 API 구현(예외 처리 필요)

## Description
- 기존에 있던 프로필 업데이트 코드를 수정하려 했지만, 폼 데이터 요청 reqeuestBody는 같이 쓰지 못한다고 하여 API 새로 작성함.
- API 엔드포인트 작성
- API 실제 로직 함수 구현
- S3URL 생성하여 반환하는 함수 구현
- 회원가입시 기본 프로필 이미지 DB에 저장되도록 함

## Screenshots
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/d3e4d8ca-3867-4841-9d2f-192a909dc247">

## Test Checklist
- [x] 테스트할 때 image 파일 올리고 난 다음 DB에 S3URL 확인 필요
- [ ] 현재 session_id값이 달라도 수정이 되는 오류가 있으니 그 부분 예외 처리 필요함.
- [ ] 이미지 파일외에 파일도 올라가는데 그 부분 찾아봐야 할듯.
