### PR TITLE
[#101]elasticsearch 1촌 검색기능 삭제, 2촌만 보이게 수정

### DIFF
--- a/backend/crud/search_crud.py
+++ b/backend/crud/search_crud.py
@@ -15,11 +15,11 @@ async def search_users_by_filters(filters: SearchFilters, session: AsyncSession)
     if not friends:
         return []
 
-    # 친구 ID 리스트 생성
-    friend_ids = [friend.friend_id for friend in friends]
+        # 1촌 친구 목록 가져옴 (중복 제거)
+    first_friend_ids = {friend.friend_id for friend in await get_friends(user_id, session, max_depth=1)}
 
-    # 중복 제거
-    friend_ids = list(set(friend_ids))
+    # 1촌을 제외한 2촌 친구 ID 리스트 생성 (중복 제거)
+    second_friend_ids = list(set(friend.friend_id for friend in friends) - first_friend_ids)
 
     # Elasticsearch 인덱스 매핑 확인
     index_mapping = es.indices.get_mapping(index="users")
@@ -41,7 +41,7 @@ async def search_users_by_filters(filters: SearchFilters, session: AsyncSession)
                     "filter": [
                         {
                             "terms": {
-                                "id": friend_ids
+                                "id": second_friend_ids
                             }
                         }
                     ]


### PR DESCRIPTION
## Summary
1촌 검색기능 삭제, 2촌만 보이게 수정

## Description
- freiend_ids -> first_friend_ids와 second_friend_ids를 분할함.
- 위 전체 리스트에서 1촌 정보 삭제하는 방식으로 코드 구현

## Screenshots
![image](https://github.com/user-attachments/assets/b6d46b2e-aa7d-47ba-bb52-55844d2aea0b)

## Test Checklist
- [ ] 1촌과 2촌의 category, company중 하나의 동일한 키워드 검색해 확인해보기
