### PR TITLE
[#111] Feat: 선물하기 로그 api 이름추가

### DIFF
--- a/backend/api/endpoints/transactions.py
+++ b/backend/api/endpoints/transactions.py
@@ -1,22 +1,22 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from Backend.backend.crud.transactions_crud import send_transaction, recieve_transaction
+from Backend.backend.crud.transactions_crud import send_transaction, receive_transaction
 from Backend.backend.database import get_db
-from Backend.backend.schemas.gift.response.gift_log_response import GiftResponseLog
+from Backend.backend.schemas.gift.response.gift_log_response import GiftLogResponseLog
 
 router = APIRouter()
 
-@router.get("/sent/{user_id}", response_model=GiftResponseLog)
+@router.get("/sent/{user_id}", response_model=GiftLogResponseLog)
 async def read_gift(user_id: int, db: AsyncSession = Depends(get_db)):
     send_log = await send_transaction(db, user_id=user_id)
     if not send_log:
         raise HTTPException(status_code=404, detail="No sent transactions found for the user")
     return {"transactions": send_log}
 
-@router.get("/received/{user_id}", response_model=GiftResponseLog)
+@router.get("/received/{user_id}", response_model=GiftLogResponseLog)
 async def receive_gift(user_id: int, db: AsyncSession = Depends(get_db)):
-    recieve_log = await recieve_transaction(db, friend_id=user_id)
-    if not recieve_log:
+    receive_log = await receive_transaction(db, friend_id=user_id)
+    if not receive_log:
         raise HTTPException(status_code=404, detail="No received transactions found for the user")
-    return {"transactions": recieve_log}
+    return {"transactions": receive_log}

--- a/backend/crud/gift_crud.py
+++ b/backend/crud/gift_crud.py
@@ -1,3 +1,4 @@
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
 from Backend.backend.models.user import User
@@ -40,3 +41,8 @@ async def create_gift_transaction(db: Session, gift: GiftSend):
         return db_gift
 
     return None
+
+async def get_user_name(db: AsyncSession, user_id: int) -> str:
+    result = await db.execute(select(User.name).filter(User.id == user_id))
+    user = result.scalars().first()
+    return user if user else "Unknown"

--- a/backend/crud/transactions_crud.py
+++ b/backend/crud/transactions_crud.py
@@ -1,14 +1,39 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from Backend.backend.models.credit_transaction import CreditTransaction
-from Backend.backend.schemas.gift.response.gift_response import GiftResponse
+from Backend.backend.schemas.gift.response.gift_log_response import GiftLogResponse
+from Backend.backend.crud.gift_crud import get_user_name
 
 async def send_transaction(db: AsyncSession, user_id: int):
+    # 트랜잭션을 조회합니다.
     result = await db.execute(select(CreditTransaction).filter(CreditTransaction.user_id == user_id))
     transactions = result.scalars().all()
-    return [GiftResponse.from_send_orm(tx) for tx in transactions]
 
-async def recieve_transaction(db: AsyncSession, friend_id: int):
+    # 사용자 이름과 친구 이름을 조회합니다.
+    user_names = {user_id: await get_user_name(db, user_id)}
+    friend_ids = {tx.friend_id for tx in transactions}
+    for friend_id in friend_ids:
+        user_names[friend_id] = await get_user_name(db, friend_id)
+
+    # 응답에 사용자 이름을 추가합니다.
+    return [
+        GiftLogResponse.from_send_orm(tx, user_names.get(tx.user_id, "Unknown"), user_names.get(tx.friend_id, "Unknown"))
+        for tx in transactions
+    ]
+
+async def receive_transaction(db: AsyncSession, friend_id: int):
+    # 트랜잭션을 조회합니다.
     result = await db.execute(select(CreditTransaction).filter(CreditTransaction.friend_id == friend_id))
     transactions = result.scalars().all()
-    return [GiftResponse.from_receive_orm(tx) for tx in transactions]
+
+    # 사용자 이름과 친구 이름을 조회합니다.
+    user_ids = {tx.user_id for tx in transactions}
+    user_names = {friend_id: await get_user_name(db, friend_id)}
+    for user_id in user_ids:
+        user_names[user_id] = await get_user_name(db, user_id)
+
+    # 응답에 사용자 이름을 추가합니다.
+    return [
+        GiftLogResponse.from_receive_orm(tx, user_names.get(tx.user_id, "Unknown"), user_names.get(tx.friend_id, "Unknown"))
+        for tx in transactions
+    ]

--- a/backend/schemas/gift/response/gift_log_response.py
+++ b/backend/schemas/gift/response/gift_log_response.py
@@ -1,11 +1,47 @@
-from typing import List
+from typing import Optional, List
 from pydantic import BaseModel
-from Backend.backend.schemas.gift.response.gift_response import GiftResponse
+from datetime import datetime
 
-class GiftResponseLog(BaseModel):
-    transactions: List[GiftResponse]
+formatted_timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+
+class GiftLogResponse(BaseModel):
+    id: int
+    user_id: int
+    user_name: str
+    friend_id: int
+    friend_name: str
+    ct_money: int
+    updated_at: Optional[datetime] = formatted_timestamp
 
     class Config:
         from_attributes = True
 
+    @staticmethod
+    def from_send_orm(transaction, user_name: str, friend_name: str):
+        return GiftLogResponse(
+            id=transaction.id,
+            user_id=transaction.user_id,
+            user_name=user_name,
+            friend_id=transaction.friend_id,
+            friend_name=friend_name,
+            ct_money=transaction.ct_money,
+            updated_at=transaction.updated_at
+        )
 
+    @staticmethod
+    def from_receive_orm(transaction, user_name: str, friend_name: str):
+        return GiftLogResponse(
+            id=transaction.id,
+            user_id=transaction.friend_id,
+            user_name=friend_name,
+            friend_id=transaction.user_id,
+            friend_name=user_name,
+            ct_money=transaction.ct_money,
+            updated_at=transaction.updated_at
+        )
+
+class GiftLogResponseLog(BaseModel):
+    transactions: List[GiftLogResponse]
+
+    class Config:
+        from_attributes = True

--- a/backend/schemas/gift/response/gift_response.py
+++ b/backend/schemas/gift/response/gift_response.py
@@ -15,22 +15,3 @@ class GiftResponse(BaseModel):
     class Config:
         from_attributes = True
 
-    @staticmethod
-    def from_send_orm(transaction):
-        return GiftResponse(
-            id=transaction.id,
-            user_id=transaction.user_id,
-            friend_id=transaction.friend_id,
-            ct_money=transaction.ct_money,
-            updated_at=transaction.updated_at
-        )
-
-    @staticmethod
-    def from_receive_orm(transaction):
-        return GiftResponse(
-            id=transaction.id,
-            user_id=transaction.friend_id,  # recieve에선 해당 위치 바꿈 why? 같은 스키마로 활용하기 때문, 프론트지장 x
-            friend_id=transaction.user_id,
-            ct_money=transaction.ct_money,
-            updated_at=transaction.updated_at
-        )


### PR DESCRIPTION
## Summary
선물하기 로그 api 이름추가

## Description
-  backend/api/endpoints/transactions.py: name이 추가된 별도의 스키마 리스트로 받아오는 코드로 수정
- backend/crud/gift_crud.py: get_user_name(아이디 받으면 이름 조회해주는 함수) 추가
- backend/crud/transactions_crud.py: 위 get_user_name에서 받아온 이름 해당 스키마에 삽입
- backend/schemas/gift/response/gift_log_response.py: 이름이 추가된 별도의 스키마 추가(전에는 같이 공유함)
- backend/schemas/gift/response/gift_response.py: (orm 이름 위치 바꾸는 함수를 gift_log_response.py로 옮김)


## Screenshots
![image](https://github.com/user-attachments/assets/e3001d03-6a1e-4b4f-954c-712385124209)


## Test Checklist
- [ ] 꼼꼼히 확인해보기! (저는 꼼꼼히 다 확인했습니당)
