### PR TITLE
[#135] Bug: 선물하기 api 외래키 문제 버그 수정

### DIFF
--- a/models/credit_transaction.py
+++ b/models/credit_transaction.py
@@ -8,15 +8,12 @@ class CreditTransaction(Base):
     __tablename__ = 'credit_transaction'
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"))
-    friend_id = Column(Integer, ForeignKey("friends.id"))
+    friend_id = Column(Integer, ForeignKey("users.id"))
     ct_money = Column(Integer)
     status = Column(String(30))
     is_deleted = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    user = relationship("User", foreign_keys=[user_id], back_populates="transactions")
-    friend = relationship("Friend", foreign_keys=[friend_id])
-
-
-User.transactions = relationship("CreditTransaction", order_by=CreditTransaction.id, back_populates="user")
+    user = relationship("User", foreign_keys=[user_id])
+    friend = relationship("User", foreign_keys=[friend_id])


### PR DESCRIPTION
## Summary
선물하기 api 외래키 문제 버그 수정

## Description
- friend_id에 foreignkey 부분 수정
- user 관계도에서  back_populates 삭제
## Screenshots

## Test Checklist
- [ ] 마지막으로 다시 확인 부탁드립니다
- [ ]
