### PR TITLE
Hotfix/#137

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,13 +10,13 @@ from .api.api import api_router
 from .database import create_tables, get_db
 from .models import User
 from .schemas import UserSearchResult, MessageCreate
-from .utils import manager, index_users, get_redis_connection
+from .utils import manager, index_users, get_redis_connection, bucket_name, s3_region
 from .crud.message_crud import create_message
 from prometheus_fastapi_instrumentator import Instrumentator
 
-origins = ["http://localhost:", "http://sml-m.site"]
+origins = ["http://localhost:", "http://sml-m.site", f"https://{bucket_name}.s3.{s3_region}.amazonaws.com/"]
 
-app = FastAPI()
+app = FastAPI(docs_url='/api/docs', openapi_url='/api/openapi.json')
 
 Instrumentator().instrument(app).expose(app)
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,4 +3,4 @@ from .db_utils import get_users_from_db
 from .es_setup import create_index
 from .index_user import index_users
 from .redis_connection import get_redis_connection
-from .s3_util import upload_image_to_s3, create_s3_url, default_profile_url
+from .s3_util import upload_image_to_s3, create_s3_url, default_profile_url, bucket_name, s3_region

--- a/utils/s3_util.py
+++ b/utils/s3_util.py
@@ -10,7 +10,7 @@ bucket_name = os.getenv("S3_BUCKET_NAME")
 s3_region = os.getenv("S3_REGION")
 s3_access_key_id = os.getenv("S3_ACCESS_KEY_ID")
 s3_secret_access_key = os.getenv("S3_SECRET_ACCESS_KEY")
-default_profile_url = f"https://{bucket_name}.s3.{s3_region}.amazonaws.com/default_profile.png"
+default_profile_url = f"https://{bucket_name}.s3.{s3_region}.amazonaws.com/default-profile.png"
 
 class Connect:
     def __init__(self):


### PR DESCRIPTION
## Summary
프론트엔드에서 S3 URL을 가져다 써서 이미지를 띄우는 과정에서 CORS 에러가 발생하여 해결
이유: default_profile이 아닌 default-profile로 이름에서 문제가 생김. 아무래도 도메인 이름 규칙을 따라야 하는 것으로 보임.

Swagger docs 에러 해결

## Description
- main.py에 app에 docs_url, openapi_url 추가
- origins 변경
- default_profile -> default-profile

## Screenshots
*실행 결과 스크린샷*

## Test Checklist
- [ ] 관계도 조회 페이지에서 기본 이미지가 뜨는지 확인.
- [ ] swagger 확인
